### PR TITLE
Use Xcode 16.1 beta on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: macos-latest
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.0.app/Contents/Developer
+      DEVELOPER_DIR: /Applications/Xcode_16.1.app/Contents/Developer
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Github latest runner has removed 16.0 beta